### PR TITLE
feat:支持异步子应用配置函数

### DIFF
--- a/packages/micro-app/src/index.tsx
+++ b/packages/micro-app/src/index.tsx
@@ -55,7 +55,7 @@ export interface AppConfig {
 }
 
 export interface ResponseModule {
-  default: (container: HTMLElement | null) => AppConfig;
+  default: (container: HTMLElement | null) => Promise<AppConfig>|AppConfig;
 }
 
 /**
@@ -81,7 +81,7 @@ export function MicroApp({
 
   useEffect(() => {
     handleLoadApp(entry)
-      .then((res) => resolveErrors(res, entry, containerRef))
+      .then( async (res) => await resolveErrors(res, entry, containerRef))
       .then((config) => {
         if (config.mount) {
           setLoading(false);
@@ -132,7 +132,7 @@ function handleLoadApp(entry: Entry): Promise<ResponseModule> {
   return import(/* @vite-ignore */ source);
 }
 
-function resolveErrors(
+async function resolveErrors(
   res: ResponseModule,
   entry: Entry,
   containerRef: RefObject<HTMLElement>
@@ -140,7 +140,7 @@ function resolveErrors(
   if (typeof res.default !== 'function') {
     return Promise.reject(`[MicroApp] - 导出格式不正确: ${entry}`);
   }
-  const config = res.default(containerRef.current) as AppConfig;
+  const config = await res.default(containerRef.current) as AppConfig;
   if (!(config.mount || config.render)) {
     return Promise.reject(
       `[MicroApp] - 导出方法缺失 'mount' 或 'render': ${entry}`

--- a/packages/micro-sub/src/defineMicroApp.ts
+++ b/packages/micro-sub/src/defineMicroApp.ts
@@ -16,7 +16,7 @@ export interface AppConfig<P> {
   unmount?: () => void;
 }
 
-type MicroCallback<P> = (container: HTMLElement) => AppConfig<P>;
+type MicroCallback<P> = (container: HTMLElement) => Promise<AppConfig<P>>|AppConfig<P>;
 
 export interface DefineApp<P> extends MicroCallback<P> {
   /**
@@ -29,8 +29,8 @@ export interface DefineApp<P> extends MicroCallback<P> {
  * 定义 micro app，额外处理样式问题
  */
 export function defineMicroApp<P>(callback: MicroCallback<P>) {
-  const defineApp: DefineApp<P> = (container: HTMLElement) => {
-    const appConfig = callback(container);
+  const defineApp: DefineApp<P> = async (container: HTMLElement) => {
+    const appConfig = await callback(container);
 
     // 处理样式局部插入
     const mountFn = appConfig.mount;


### PR DESCRIPTION
支持了创建子应用时的函数里支持异步：
```ts
export default defineMicroApp(async (container: HTMLElement) => {
  const app = createApp(App);

  await appInit(app);

  return {
    mount(forwardProps: ForwardProps) {
      console.log('[vue mount]');
      backupToHomeRouterFunc = forwardProps?.backupToHomeRouterFunc;
      app.mount(container);
      console.log(container);
    },
    unmount() {
      console.log('[vue unmount]');
      app.unmount();
    },
  };
});
```